### PR TITLE
Upgrade Vaadin version from 8.0.0 to 8.4.1.  Fix #9

### DIFF
--- a/touchkit/pom.xml
+++ b/touchkit/pom.xml
@@ -81,8 +81,8 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vaadin.version.maven>8.0.0</vaadin.version.maven>
-        <vaadin.plugin.version>8.0.0</vaadin.plugin.version>
+        <vaadin.version.maven>8.4.1</vaadin.version.maven>
+        <vaadin.plugin.version>8.4.1</vaadin.plugin.version>
         <snapshot.repository.url>http://oss.sonatype.org/content/repositories/vaadin-snapshots/</snapshot.repository.url>
         <jetty.version>9.2.14.v20151106</jetty.version>
         <Implementation-Version>${project.version}</Implementation-Version>


### PR DESCRIPTION
Upgrades the Vaadin version to the currently newest stable Vaadin 8.