### PR TITLE
Feature/osgi support

### DIFF
--- a/touchkit/pom.xml
+++ b/touchkit/pom.xml
@@ -90,6 +90,10 @@
         <Implementation-Title>TouchKit</Implementation-Title>
         <Implementation-Vendor>${project.organization.name}</Implementation-Vendor>
         <Vaadin-Addon>touchkit-${project.version}.jar</Vaadin-Addon>
+        <maven.bundle.plugin.version>2.5.3</maven.bundle.plugin.version>
+        <karaf.version>4.1.5</karaf.version>
+        <Bundle-SymbolicName>org.vaadin.${project.artifactId}</Bundle-SymbolicName>
+        <osgi.service.version>1.3.0</osgi.service.version>
     </properties>
 
     <description>Provides components and features for mobile devices.</description>
@@ -97,7 +101,7 @@
     <build>
         <resources>
             <!-- These are also needed for the sources required by the GWT compiler
-            to be included in the produced JARs -->
+                 to be included in the produced JARs -->
             <resource>
                 <directory>src/main/java</directory>
             </resource>
@@ -153,7 +157,7 @@
                         <manifest>
                             <addClasspath>true</addClasspath>
                             <!-- Implementation-Title and Implementation-Version come from the
-                            POM by default -->
+                                 POM by default -->
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                         </manifest>
                         <manifestEntries>
@@ -166,6 +170,64 @@
                         </manifestEntries>
                     </archive>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>${maven.bundle.plugin.version}</version>
+                <configuration>
+                    <supportedProjectTypes>
+                        <supportedProjectType>jar</supportedProjectType>
+                        <supportedProjectType>bundle</supportedProjectType>
+                        <supportedProjectType>war</supportedProjectType>
+                    </supportedProjectTypes>
+                    <instructions>
+                        <Bundle-SymbolicName>${Bundle-SymbolicName}</Bundle-SymbolicName>
+                        <Import-Package>*;resolution:=optional</Import-Package>
+                        <Export-Package>org.vaadin.touchkit.*</Export-Package>
+                        <Include-Resource>target/classes</Include-Resource>
+                        <_removeheaders>
+                            Private-Package,
+                            Include-Resource,
+                            Embed-Dependency,
+                            Embed-Transitive
+                        </_removeheaders>
+                        <!-- Enable processing of OSGI DS component annotations -->
+                        <_dsannotations>*</_dsannotations>
+                        <!-- Enable processing of OSGI metatype annotations -->
+                        <_metatypeannotations>*</_metatypeannotations>
+                    </instructions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle</id>
+                        <goals>
+                            <goal>bundle</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.karaf.tooling</groupId>
+                <artifactId>karaf-maven-plugin</artifactId>
+                <version>${karaf.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <startLevel>80</startLevel>
+                    <includeTransitiveDependency>false</includeTransitiveDependency>
+                    <aggregateFeatures>false</aggregateFeatures>
+                    <includeProjectArtifact>true</includeProjectArtifact>
+                    <primaryFeatureName>${karaf-feature-name}</primaryFeatureName>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>generate-features-file</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>features-generate-descriptor</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <!-- Compiles your custom GWT components with the GWT compiler -->
             <plugin>
@@ -206,6 +268,17 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.component.annotations</artifactId>
+            <version>${osgi.service.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-osgi-integration</artifactId>
+            <version>${vaadin.version.maven}</version>
+        </dependency>
+        <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-server</artifactId>
             <version>${vaadin.version.maven}</version>
@@ -226,7 +299,6 @@
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-client</artifactId>
             <version>${vaadin.version.maven}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/touchkit/pom.xml
+++ b/touchkit/pom.xml
@@ -78,7 +78,7 @@
             <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
     </licenses>
-    
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <vaadin.version.maven>8.0.0</vaadin.version.maven>
@@ -132,7 +132,7 @@
                     <encoding>UTF-8</encoding>
                 </configuration>
                 <version>3.0.2</version>
-            </plugin>            
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
@@ -194,10 +194,10 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin> 
+            </plugin>
         </plugins>
     </build>
-	
+
     <dependencies>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/touchkit/src/main/java/org/vaadin/osgi/touchkit/themes/TouchKitTheme.java
+++ b/touchkit/src/main/java/org/vaadin/osgi/touchkit/themes/TouchKitTheme.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.vaadin.osgi.touchkit.themes;
+
+import org.osgi.service.component.annotations.Component;
+
+import com.vaadin.osgi.resources.OsgiVaadinTheme;
+
+@Component(service=OsgiVaadinTheme.class, immediate=true)
+public class TouchKitTheme implements OsgiVaadinTheme {
+
+    @Override
+    public String getName() {
+        return "touchkit";
+    }
+
+}

--- a/touchkit/src/main/java/org/vaadin/osgi/touchkit/widgetset/TouchKitWidgetset.java
+++ b/touchkit/src/main/java/org/vaadin/osgi/touchkit/widgetset/TouchKitWidgetset.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.vaadin.osgi.touchkit.widgetset;
+
+import org.osgi.service.component.annotations.Component;
+
+import com.vaadin.osgi.resources.OsgiVaadinWidgetset;
+
+@Component(service=OsgiVaadinWidgetset.class, immediate=true)
+public class TouchKitWidgetset implements OsgiVaadinWidgetset {
+
+    @Override
+    public String getName() {
+        return "org.vaadin.touchkit.gwt.TouchKitWidgetSet";
+    }
+
+}

--- a/touchkit/src/test/java/org/vaadin/osgi/touchkit/themes/TouchKitThemeTest.java
+++ b/touchkit/src/test/java/org/vaadin/osgi/touchkit/themes/TouchKitThemeTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.vaadin.osgi.touchkit.themes;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.vaadin.osgi.touchkit.themes.TouchKitTheme;
+
+public class TouchKitThemeTest {
+
+    @Test
+    public void testGetName() {
+        TouchKitTheme theme = new TouchKitTheme();
+
+        assertEquals("touchkit", theme.getName());
+    }
+
+}

--- a/touchkit/src/test/java/org/vaadin/osgi/touchkit/widgetset/TouchKitWidgetsetTest.java
+++ b/touchkit/src/test/java/org/vaadin/osgi/touchkit/widgetset/TouchKitWidgetsetTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.vaadin.osgi.touchkit.widgetset;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class TouchKitWidgetsetTest {
+
+    @Test
+    public void testGetName() {
+        TouchKitWidgetset widgetset = new TouchKitWidgetset();
+
+        assertEquals("org.vaadin.touchkit.gwt.TouchKitWidgetSet", widgetset.getName());
+    }
+
+}


### PR DESCRIPTION
Adds OSGi support to TouchKit 5.0.1-SNAPSHOT, the changes are:

1. Make the jar file be an OSGi bundle, with resolution:=optional on all imports
2. Add an apache karaf feature repository defining a feature called "touchkit" and attach it to the touchkit maven artifact (can be installed in karaf with the command "feature:install touchkit")
3. Add an OSGi component publishing the TouchKit widgetset (as outlined in [Vaadin OSGi Support](https://vaadin.com/docs/v8/framework/advanced/advanced-osgi.html))
4. Add an OSGi component publishing the "touchkit" theme (as outlined in [Vaadin OSGi Support](https://vaadin.com/docs/v8/framework/advanced/advanced-osgi.html))